### PR TITLE
Add SSL verification because we're in 2019

### DIFF
--- a/examples/PHP/JSON_clean.php
+++ b/examples/PHP/JSON_clean.php
@@ -32,7 +32,8 @@ class JsonSklik {
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 1);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $request);
 

--- a/examples/PHP/XMLRPC_clean.php
+++ b/examples/PHP/XMLRPC_clean.php
@@ -33,7 +33,8 @@ class XmlRpcSklik {
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 1);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $request);
 


### PR DESCRIPTION
Please turn on SSL verification in your examples - turning it explicitly off should not be in any examples on the internet today.

Thanks!